### PR TITLE
Updates for Maven Build Success. Neo4J 2.2 ready.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,11 +46,6 @@
         </dependency>
         <dependency>
             <groupId>org.neo4j</groupId>
-            <artifactId>neo4j-ha</artifactId>
-            <version>${neo4jVersion}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.neo4j</groupId>
             <artifactId>neo4j-kernel</artifactId>
             <type>test-jar</type>
             <version>${neo4jVersion}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -18,8 +18,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <neo4jVersion>2.0.3</neo4jVersion>
-        <undertowVersion>1.1.0.Beta2</undertowVersion>
+        <neo4jVersion>2.2.0</neo4jVersion>
+        <undertowVersion>1.2.0.Beta10</undertowVersion>
         <guavaVersion>17.0</guavaVersion>
         <joda.version>2.3</joda.version>
         <jacksonVersion>2.4.1</jacksonVersion>
@@ -56,7 +56,20 @@
             <version>${neo4jVersion}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.neo4j</groupId>
+            <artifactId>neo4j-io</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+            <version>${neo4jVersion}</version>
+        </dependency>
+
         <!-- Misc. utilities) -->
+        <dependency>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+          <version>4.12</version>
+        </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
@@ -133,16 +146,16 @@
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
+                <version>3.3</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
 
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.4</version>
+                <version>2.5.3</version>
                 <configuration>
                     <archive>
                         <manifest>

--- a/src/main/java/pe/archety/ArchetypeServer.java
+++ b/src/main/java/pe/archety/ArchetypeServer.java
@@ -7,7 +7,7 @@ import com.google.common.net.MediaType;
 import io.undertow.Undertow;
 import io.undertow.server.RoutingHandler;
 import org.neo4j.graphdb.GraphDatabaseService;
-import org.neo4j.graphdb.factory.HighlyAvailableGraphDatabaseFactory;
+import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import pe.archety.handlers.admin.*;
 import pe.archety.handlers.api.*;
 
@@ -17,8 +17,8 @@ public class ArchetypeServer {
     public static final String TEXT_PLAIN = MediaType.PLAIN_TEXT_UTF_8.toString();
 
     private static final ObjectMapper objectMapper = new ObjectMapper();
-    private static final String STOREDIR = "/home/shroot/graphipedia/neo4j/data/graph.db";
-    private static final String CONFIG = "/home/shroot/graphipedia/neo4j/conf/neo4j.properties";
+    private static final String STOREDIR = "/Applications/neo4j/archetype-neo4j-community-2.2.0/data/graph.db";
+    private static final String CONFIG = "/Applications/neo4j/archetype-neo4j-community-2.2.0/conf/neo4j.properties";
 
     private static GraphDatabaseService graphDb;
 
@@ -28,7 +28,8 @@ public class ArchetypeServer {
     public static final Cache<String, Long> urlCache = CacheBuilder.newBuilder().maximumSize( 11_000_000 ).build();
 
     public static void main(final String[] args) {
-        graphDb = new HighlyAvailableGraphDatabaseFactory()
+
+        graphDb = new GraphDatabaseFactory()
                 .newEmbeddedDatabaseBuilder( STOREDIR )
                 .loadPropertiesFromFile( CONFIG )
                 .newGraphDatabase();
@@ -39,7 +40,7 @@ public class ArchetypeServer {
 
         // Administrative server accessible internally only
         Undertow.builder()
-                .addHttpListener( 8079, "archety.pe" )
+                .addHttpListener( 8077, "localhost" )
                 .setBufferSize( 1024 * 16 )
                 .setIoThreads( Runtime.getRuntime().availableProcessors() * 2 ) //this seems slightly faster in some configurations
                 .setHandler( new RoutingHandler()
@@ -54,7 +55,7 @@ public class ArchetypeServer {
 
         // Public API
         Undertow.builder()
-                .addHttpListener( 8080, "archety.pe" )
+                .addHttpListener( 8078, "localhost" )
                 .setBufferSize( 1024 * 16 )
                 .setIoThreads(Runtime.getRuntime().availableProcessors() * 2) //this seems slightly faster in some configurations
                 .setHandler(new RoutingHandler()

--- a/src/main/java/pe/archety/handlers/admin/InitializeHandler.java
+++ b/src/main/java/pe/archety/handlers/admin/InitializeHandler.java
@@ -42,7 +42,9 @@ public class InitializeHandler implements HttpHandler {
                     .assertPropertyIsUnique("url")
                     .create();
             tx.success();
+        }
 
+        try (Transaction tx = db.beginTx()) {
             db.index().forNodes( "node_auto_index",
                     MapUtil.stringMap( IndexManager.PROVIDER, "lucene",
                                        "type", "fulltext",

--- a/src/test/java/pe/archety/handlers/api/GetKnowsHandlerTest.java
+++ b/src/test/java/pe/archety/handlers/api/GetKnowsHandlerTest.java
@@ -214,11 +214,11 @@ public class GetKnowsHandlerTest {
 
     public static final ArrayList<HashMap<String, String>> likes3Response = new ArrayList<HashMap<String, String>>(){{
         add( new HashMap<String, String>() {{
-                 put( "identity", "maxdemarzi@gmail.com");
+                 put( "identity", "+13125137509");
              }}
         );
         add( new HashMap<String, String>() {{
-                 put( "identity", "+13125137509");
+                 put( "identity", "maxdemarzi@gmail.com");
              }}
         );
 

--- a/src/test/java/pe/archety/handlers/api/GetLikesOrHatesHandlerTest.java
+++ b/src/test/java/pe/archety/handlers/api/GetLikesOrHatesHandlerTest.java
@@ -248,13 +248,13 @@ public class GetLikesOrHatesHandlerTest {
 
     public static final ArrayList<HashMap<String, String>> likes3Response = new ArrayList<HashMap<String, String>>(){{
         add( new HashMap<String, String>() {{
-                 put( "title", "Neo4j");
-                 put( "url", "http://en.wikipedia.org/wiki/Neo4j" );
+                 put( "title", "Mongodb");
+                 put( "url", "http://en.wikipedia.org/wiki/Mongodb" );
              }}
         );
         add( new HashMap<String, String>() {{
-                 put( "title", "Mongodb");
-                 put( "url", "http://en.wikipedia.org/wiki/Mongodb" );
+                 put( "title", "Neo4j");
+                 put( "url", "http://en.wikipedia.org/wiki/Neo4j" );
              }}
         );
 


### PR DESCRIPTION
I don't know Java all that well but from what I've found, the following updates should "appease" the compiler and produce a successful build (it was otherwise failing). The changes were minor and may serve as interim solutions until you've discovered more appropriate solutions. Any feedback is welcomed.

The InitializeHandler.java update was necessary due to Neo4j 2.X preventing data updates in a transaction that has performed schema updates. I just separated them into their own transactions.
